### PR TITLE
스타일 수정: hr, .footnotes, code

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -2171,7 +2171,7 @@ article.post a:hover {
 }
 article.post hr {
   border: none;
-  height: auto !important;
+  height: auto;
   margin: 40px auto 80px;
   text-align: center;
 }

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -2171,6 +2171,7 @@ article.post a:hover {
 }
 article.post hr {
   border: none;
+  height: auto !important;
   margin: 40px auto 80px;
   text-align: center;
 }
@@ -2255,7 +2256,6 @@ article.post blockquote p {
   color: #888;
 }
 article.post code {
-  background-color: rgba(0, 0, 0, 0.04);
   color: #333;
 }
 article.post code td.code {
@@ -2459,6 +2459,22 @@ article.post .button-area {
 }
 article.post .button-area a {
   display: inline-block;
+}
+article.post .footnotes ol {
+  padding: 0 2em;
+}
+article.post .footnotes ol > li {
+  display: flex;
+  margin: 10px 0;
+}
+article.post .footnotes ol > li:before {
+  left: -22px;
+  max-width: 10px;
+}
+article.post .footnotes ol > li p {
+  padding-top: 0;
+  margin: 0;
+  flex: 1;
 }
 .post-preview h2 {
   color: #333;

--- a/assets/less/style.less
+++ b/assets/less/style.less
@@ -1,5 +1,5 @@
-@import "variables.less";
-@import "mixins.less";
+@import "variables";
+@import "mixins";
 @import "../icon/css/ridicorp-icon.css";
 @import "../css/zoom.css";
 
@@ -1809,6 +1809,7 @@ article.post {
 	}
 	hr {
 		border: none;
+		height: auto !important;
 		margin: 40px auto 80px;
 		text-align: center;
 		&:before {
@@ -1895,7 +1896,6 @@ article.post {
 		}
 	}
 	code {
-		background-color: rgba(0,0,0,0.04);
 		color: #333;
 	}
 	code td.code {
@@ -2054,6 +2054,25 @@ article.post {
 		padding-top: 50px;
 		a {
 			display: inline-block;
+		}
+	}
+	// Footnotes
+	.footnotes {
+		ol {
+			padding: 0 2em;
+			& > li {
+				display: flex;
+				margin: 10px 0;
+				&:before {
+				    left: -22px;
+					max-width: 10px;
+				}
+				p {
+					padding-top: 0;
+					margin: 0;
+					flex: 1;
+				}
+			}
 		}
 	}
 }

--- a/assets/less/style.less
+++ b/assets/less/style.less
@@ -1809,7 +1809,7 @@ article.post {
 	}
 	hr {
 		border: none;
-		height: auto !important;
+		height: auto;
 		margin: 40px auto 80px;
 		text-align: center;
 		&:before {


### PR DESCRIPTION
- hr 태그의 height 속성이 bootstrap 때문에 0으로 고정되는 문제 수정
- .footnotes 영역 레이아웃 수정
- code 태그에 포함된 문자열에 추가적으로 음영이 더 들어가는 문제 수정

### .footnotes, hr

#### before
<img width="698" alt="2017-11-09 4 10 40" src="https://user-images.githubusercontent.com/8926395/32592793-b486b78c-c568-11e7-8874-79c3eb9a6bf6.png">

#### after
<img width="700" alt="2017-11-09 4 10 52" src="https://user-images.githubusercontent.com/8926395/32592771-9cf02d1a-c568-11e7-9cc0-69e180fec1e7.png">


### code

#### before
<img width="704" alt="2017-11-09 4 08 06" src="https://user-images.githubusercontent.com/8926395/32592687-419aaa80-c568-11e7-8004-d4ed7e6675eb.png">

#### after
<img width="707" alt="2017-11-09 4 08 23" src="https://user-images.githubusercontent.com/8926395/32592688-41be6c7c-c568-11e7-8acb-300e3e0084ad.png">
