### PR TITLE
Support a CORS connections with intra.ridi.com

### DIFF
--- a/press/index.html
+++ b/press/index.html
@@ -224,7 +224,7 @@ root_class: "press page"
     }
 
     function refreshArticleInfo() {
-      $.getJSON('https://intra.ridi.com/press/list?page=' + (cur_page + 1) + '&items_per_page=' + ARTICLES_PER_PAGE, 1, function (data) {
+      $.getJSON('https://intra.ridi.com/press/list?page=' + (cur_page + 1) + '&items_per_page=' + ARTICLES_PER_PAGE, null, function (data) {
         setArticles(data);
       });
     }

--- a/press/index.html
+++ b/press/index.html
@@ -224,7 +224,7 @@ root_class: "press page"
     }
 
     function refreshArticleInfo() {
-      $.getJSON('https://intra.ridi.com/press/list?callback=?&page=' + (cur_page + 1) + '&items_per_page=' + ARTICLES_PER_PAGE, null, function (data) {
+      $.getJSON('https://intra.ridi.com/press/list?page=' + (cur_page + 1) + '&items_per_page=' + ARTICLES_PER_PAGE, 1, function (data) {
         setArticles(data);
       });
     }


### PR DESCRIPTION
## 개요
https://github.com/ridi/intranet/pull/259

> jsonp 기술로 ridicorp.com에서 intra.ridi.com의 정보를 가져오고 있습니다. 하지만 JSONP는 보안 상의 이슈로 (위의 개요를 포함한) HTTP 통신을 권장하고 있습니다.

## 변경사항 
기존 jsonp을 위해 작성된 callback 파라미터를 제거하였습니다.