### PR TITLE
메인 리디 바탕 설명에 keep-all 추가

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -1132,6 +1132,7 @@ article.post .footnotes ol > li p {
 .ridibating-banner .content-wrapper div p {
   font-family: 'RIDIBatang';
   font-size: 24px;
+  word-break: keep-all;
   line-height: 1.6em;
   color: #fff;
 }

--- a/assets/less/components/content.less
+++ b/assets/less/components/content.less
@@ -194,6 +194,7 @@
       p {
         font-family: @ridibatang;
         font-size: 24px;
+        word-break: keep-all;
         line-height: 1.6em;
         color: @white;
         @media @queries_sm {

--- a/index.html
+++ b/index.html
@@ -177,7 +177,7 @@ root_class: "about page"
   <div class="content-wrapper site-content">
       <div class="banner-info">
         <span class="banner-title">전자책 전용 글꼴 리디바탕</span>
-        <p><span class="line-break">더 선명하고, 긴 문장도 잘 읽을 수 있는</span><span class="line-break">전자책 전용 글꼴 리디바탕을 소개합니다.</span></p>
+        <p><span class="line-break">더 선명하고, 긴 문장도 잘 읽을 수 있는 </span><span class="line-break">전자책 전용 글꼴 리디바탕을 소개합니다.</span></p>
       </div>
       <a href="{{ '/branding/fonts/ridibatang' | prepend: site.baseurl }}">바로가기</a>
   </div>


### PR DESCRIPTION
리디 바탕에 대한 설명에 keep-all 이 없는 거 같아 붙였습니다. 

```
더 선명하고, 긴 문장도 잘 읽을 수 있는전자책 전용 글꼴 리디바탕을 소개합니다.
```
라고 나오는 경우가 있어 공백을 추가 했습니다.   

